### PR TITLE
Added Dockerfile build of statiks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Inspired by https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324
+
+ARG GOOS=linux
+ARG GOARCH=amd64
+ARG CGO_ENABLED=0
+
+# Build 'statiks' as a self-contained, statically linked, minimal image
+FROM golang:1.11 as builder
+RUN go get -u github.com/golang/dep/...
+ENV BUILD_DIR=/go/src/github.com/halverneus/static-file-server
+RUN mkdir -p ${BUILD_DIR}
+WORKDIR ${BUILD_DIR}
+COPY Gopkg.* *.go *.md ./
+COPY ./lib ./lib/
+
+RUN dep ensure -v
+
+COPY Makefile ./
+RUN CGO_ENABLED=${CGO_ENABLED:-0} GOOS=${GOOS:-linux} GOARCH=${GOARCH:-amd64} make build_optimized
+RUN mkdir -p /out /out/www \
+ && cp ./statiks /out/statiks \
+ && echo '<!doctype html> <h1><a href="https://github.com/janiltonmaciel/statiks">statiks</a> works</h1><img src="./img.svg"/>' > /out/www/index.html \
+ && echo '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500"></svg>' > /out/www/img.svg \
+ && true
+
+
+# Assemble 'statiks' minimal image using statically linked build
+FROM scratch as release
+COPY --from=builder /out/statiks /
+ENTRYPOINT ["/statiks"]
+USER 1000
+## Serve all requests with a max-age of 15 minutes
+CMD ["--host", "0.0.0.0", "--max-age", "900000", "/www"]
+
+FROM release as demo
+COPY --from=builder /out/www /www/

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,21 @@ build:
 	echo "Building $(PROJECT)"
 	go build -ldflags "$(LDFLAGS)" -o $(PROJECT) main.go
 
+## Build static & optimized
+build_optimized:
+	echo "Building $(PROJECT) -- Optimized"
+	go build -a -installsuffix cgo -ldflags "-w -s" -o $(PROJECT) main.go
+
+## Build Docker Image (uses docker multi-stage builds)
+docker:
+	echo "Building Docker Image of $(PROJECT)"
+	docker build --target release -t $(PROJECT) .
+
+## Run minimal demo from Docker Image (uses docker multi-stage builds)
+docker_demo:
+	docker build --target demo -t $(PROJECT):demo .
+	docker run --rm -it -p 9080:9080 $(PROJECT):demo
+
 ## Release of the project
 release: git-tag
 	@if [ ! "$(GITHUB_TOKEN)" ]; then \


### PR DESCRIPTION
Thanks for creating Statiks! It was the best GoLang static server I found (in a quick search) that directly addressed caching and compression. I plan to use it as part of a local CDN running within a docker swarm.

This PR adds docker image building, including a tailored `Dockerfile` and additions to `Makefile`. Assuming you have docker installed, `make docker_demo` will build and run a mini demo site.

You can also try the image I published to my own account — `docker run --rm -it -p 9080:9080 shane/statiks:demo` and then browse the mini demo site.

Feedback welcome.

Cheers,
-Shane
